### PR TITLE
Pack only threads with nonempty logs

### DIFF
--- a/logstore/lstoreds/addr_book.go
+++ b/logstore/lstoreds/addr_book.go
@@ -258,7 +258,7 @@ func (ab *DsAddrBook) AddrsEdge(t thread.ID) (uint64, error) {
 		}
 	}
 	if len(as) == 0 {
-		return 0, core.ErrThreadNotFound
+		return EmptyEdgeValue, core.ErrThreadNotFound
 	}
 
 	var (

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -207,7 +207,7 @@ func (hb *dsHeadBook) getEdge(tid thread.ID, key ds.Key) (uint64, error) {
 		}
 	}
 	if len(hs) == 0 {
-		return 0, core.ErrThreadNotFound
+		return EmptyEdgeValue, core.ErrThreadNotFound
 	}
 
 	var (

--- a/logstore/lstoreds/logstore.go
+++ b/logstore/lstoreds/logstore.go
@@ -16,6 +16,8 @@ import (
 // Define if storage will accept empty dumps.
 var AllowEmptyRestore = false
 
+const EmptyEdgeValue uint64 = 0
+
 // Configuration object for datastores
 type Options struct {
 	// The size of the in-memory cache. A value of 0 or lower disables the cache.

--- a/net/client.go
+++ b/net/client.go
@@ -20,6 +20,7 @@ import (
 	core "github.com/textileio/go-threads/core/net"
 	"github.com/textileio/go-threads/core/thread"
 	sym "github.com/textileio/go-threads/crypto/symmetric"
+	"github.com/textileio/go-threads/logstore/lstoreds"
 	pb "github.com/textileio/go-threads/net/pb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -419,11 +420,8 @@ func (s *server) exchangeEdges(ctx context.Context, pid peer.ID, tids []thread.I
 	// fill local edges
 	for _, tid := range tids {
 		switch addrsEdge, headsEdge, err := s.localEdges(tid); err {
-		case errNoAddrsEdge:
-			log.With("thread", tid.String()).Warnf("cannot compute edges for thread: no addresses")
-		case errNoHeadsEdge:
-			log.With("thread", tid.String()).Debugf("cannot compute edges for threads: no heads")
-		case nil:
+		// we have emptyEdgeValue for headsEdge and addrsEdge if we get errors below
+		case errNoAddrsEdge, errNoHeadsEdge, nil:
 			body.Threads = append(body.Threads, &pb.ExchangeEdgesRequest_Body_ThreadEntry{
 				ThreadID:    &pb.ProtoThreadID{ID: tid},
 				HeadsEdge:   headsEdge,
@@ -486,17 +484,21 @@ func (s *server) exchangeEdges(ctx context.Context, pid peer.ID, tids []thread.I
 
 		// get local edges potentially updated by another process
 		addrsEdgeLocal, headsEdgeLocal, err := s.localEdges(tid)
-		if err != nil {
+		// we allow local edges to be empty, because the other peer can still have more information
+		if err != nil && (err != errNoHeadsEdge || err != errNoAddrsEdge) {
 			log.With("thread", tid.String()).With("peer", pid.String()).Errorf("second retrieval of local edges failed: %v", err)
 			continue
 		}
 
-		if e.GetAddressEdge() != addrsEdgeLocal {
+		responseEdge := e.GetAddressEdge()
+		if responseEdge != addrsEdgeLocal && responseEdge != lstoreds.EmptyEdgeValue {
 			if s.net.queueGetLogs.Schedule(pid, tid, callPriorityLow, s.net.updateLogsFromPeer) {
 				log.With("thread", tid.String()).With("peer", pid.String()).Debugf("log information update for thread scheduled")
 			}
 		}
-		if e.GetHeadsEdge() != headsEdgeLocal {
+
+		responseEdge = e.GetHeadsEdge()
+		if responseEdge != headsEdgeLocal && responseEdge != lstoreds.EmptyEdgeValue {
 			if s.net.queueGetRecords.Schedule(pid, tid, callPriorityLow, s.net.updateRecordsFromPeer) {
 				log.With("thread", tid.String()).With("pid", pid.String()).Debugf("record update for thread scheduled")
 			}

--- a/net/client.go
+++ b/net/client.go
@@ -477,7 +477,7 @@ func (s *server) exchangeEdges(ctx context.Context, pid peer.ID, tids []thread.I
 	}
 
 	for i, e := range reply.GetEdges() {
-		var tid = tids[i]
+		var tid = body.Threads[i].ThreadID.ID
 		if !e.GetExists() {
 			log.With("thread", tid.String()).With("peer", pid.String()).Warnf("exchangeEdges got not existed thread")
 			// invariant: respondent itself must request missing thread info

--- a/net/client.go
+++ b/net/client.go
@@ -485,7 +485,7 @@ func (s *server) exchangeEdges(ctx context.Context, pid peer.ID, tids []thread.I
 		// get local edges potentially updated by another process
 		addrsEdgeLocal, headsEdgeLocal, err := s.localEdges(tid)
 		// we allow local edges to be empty, because the other peer can still have more information
-		if err != nil && (err != errNoHeadsEdge || err != errNoAddrsEdge) {
+		if err != nil && err != errNoHeadsEdge && err != errNoAddrsEdge {
 			log.With("thread", tid.String()).With("peer", pid.String()).Errorf("second retrieval of local edges failed: %v", err)
 			continue
 		}

--- a/net/net.go
+++ b/net/net.go
@@ -1346,9 +1346,6 @@ PullCycle:
 					for _, pid := range peers {
 						compressor.Add(pid, tid)
 					}
-					if len(peers) == 0 {
-						compressor.Add("", tid)
-					}
 				}
 
 				idx++

--- a/net/net.go
+++ b/net/net.go
@@ -1339,12 +1339,14 @@ PullCycle:
 			select {
 			case <-ticker.C:
 				var tid = ts[idx]
-				if _, peers, err := n.threadOffsets(tid); err != nil {
+				if offsets, peers, err := n.threadOffsets(tid); err != nil {
 					log.Errorf("error getting thread info %s: %s", tid, err)
 					return
 				} else {
 					for _, pid := range peers {
-						compressor.Add(pid, tid)
+						if offsets[pid] != cid.Undef {
+							compressor.Add(pid, tid)
+						}
 					}
 				}
 

--- a/net/net.go
+++ b/net/net.go
@@ -1339,14 +1339,15 @@ PullCycle:
 			select {
 			case <-ticker.C:
 				var tid = ts[idx]
-				if offsets, peers, err := n.threadOffsets(tid); err != nil {
+				if _, peers, err := n.threadOffsets(tid); err != nil {
 					log.Errorf("error getting thread info %s: %s", tid, err)
 					return
 				} else {
 					for _, pid := range peers {
-						if offsets[pid] != cid.Undef {
-							compressor.Add(pid, tid)
-						}
+						compressor.Add(pid, tid)
+					}
+					if len(peers) == 0 {
+						compressor.Add("", tid)
 					}
 				}
 

--- a/net/pb/net.pb.go
+++ b/net/pb/net.pb.go
@@ -1080,7 +1080,7 @@ func (m *ExchangeEdgesReply) GetEdges() []*ExchangeEdgesReply_ThreadEdges {
 type ExchangeEdgesReply_ThreadEdges struct {
 	// threadID is the requested thread's ID.
 	ThreadID *ProtoThreadID `protobuf:"bytes,1,opt,name=threadID,proto3,customtype=ProtoThreadID" json:"threadID,omitempty"`
-	// exists is the flag indicating whether the requested thread exists on a respondent.
+	// deprecated, use default values for addressEdge and headsEdge
 	Exists bool `protobuf:"varint,2,opt,name=exists,proto3" json:"exists,omitempty"`
 	// addressEdge is the current hash of peers addresses stored on a respondent.
 	AddressEdge uint64 `protobuf:"varint,3,opt,name=addressEdge,proto3" json:"addressEdge,omitempty"`
@@ -3399,10 +3399,7 @@ func (m *Header) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -3592,10 +3589,7 @@ func (m *Log) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -3781,10 +3775,7 @@ func (m *Log_Record) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -3906,10 +3897,7 @@ func (m *GetLogsRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4029,10 +4017,7 @@ func (m *GetLogsRequest_Body) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4116,10 +4101,7 @@ func (m *GetLogsReply) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4241,10 +4223,7 @@ func (m *PushLogRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4435,10 +4414,7 @@ func (m *PushLogRequest_Body) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4488,10 +4464,7 @@ func (m *PushLogReply) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4613,10 +4586,7 @@ func (m *GetRecordsRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4770,10 +4740,7 @@ func (m *GetRecordsRequest_Body) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4912,10 +4879,7 @@ func (m *GetRecordsRequest_Body_LogEntry) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -4999,10 +4963,7 @@ func (m *GetRecordsReply) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -5157,10 +5118,7 @@ func (m *GetRecordsReply_LogEntry) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -5282,10 +5240,7 @@ func (m *PushRecordRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -5441,10 +5396,7 @@ func (m *PushRecordRequest_Body) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -5494,10 +5446,7 @@ func (m *PushRecordReply) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -5619,10 +5568,7 @@ func (m *ExchangeEdgesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -5706,10 +5652,7 @@ func (m *ExchangeEdgesRequest_Body) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -5832,10 +5775,7 @@ func (m *ExchangeEdgesRequest_Body_ThreadEntry) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -5919,10 +5859,7 @@ func (m *ExchangeEdgesReply) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {
@@ -6065,10 +6002,7 @@ func (m *ExchangeEdgesReply_ThreadEdges) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthNet
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthNet
 			}
 			if (iNdEx + skippy) > l {

--- a/net/pb/net.proto
+++ b/net/pb/net.proto
@@ -174,7 +174,7 @@ message ExchangeEdgesReply {
     message ThreadEdges {
         // threadID is the requested thread's ID.
         bytes threadID = 1 [(gogoproto.customtype) = "ProtoThreadID"];
-        // exists is the flag indicating whether the requested thread exists on a respondent.
+        // deprecated, use default values for addressEdge and headsEdge
         bool exists = 2;
         // addressEdge is the current hash of peers addresses stored on a respondent.
         uint64 addressEdge = 3;

--- a/net/server.go
+++ b/net/server.go
@@ -344,9 +344,11 @@ func (s *server) ExchangeEdges(ctx context.Context, req *pb.ExchangeEdgesRequest
 			// need to get new logs only if we have non empty addresses on remote and the hashes are different
 			if addrsEdgeRemote != lstoreds.EmptyEdgeValue {
 				if addrsEdgeLocal != addrsEdgeRemote {
+					prt := callPriorityLow
 					updateLogs := s.net.updateLogsFromPeer
 					// if we don't have the thread locally
 					if addrsEdgeLocal == lstoreds.EmptyEdgeValue {
+						prt = callPriorityHigh
 						updateLogs = func(ctx context.Context, p peer.ID, t thread.ID) error {
 							if err := s.net.updateLogsFromPeer(ctx, p, t); err != nil {
 								return err
@@ -357,7 +359,7 @@ func (s *server) ExchangeEdges(ctx context.Context, req *pb.ExchangeEdgesRequest
 							return nil
 						}
 					}
-					if s.net.queueGetLogs.Schedule(pid, tid, callPriorityLow, updateLogs) {
+					if s.net.queueGetLogs.Schedule(pid, tid, prt, updateLogs) {
 						log.With("peer", pid.String()).With("thread", tid.String()).Debugf("log information update for thread %s from %s scheduled", tid, pid)
 					}
 				}


### PR DESCRIPTION
This PR fixes the following problem: we call `exchangeEdges` in respect of the threads all logs of which have no heads, this results in a lot of error messages with respect to such threads. So the idea is to filter such threads in the packing step.

Also this PR fixes a bug with incorrect indexing of the threads which are sent in the `exchangeEdges` step. For example if we filter some thread before sending the request it doesn't go into `body.Threads`. So the `len(reply.GetEdges())` will be less than `len(tids)` which results in incorrect indexing, the fix is to use exactly the threads that were sent in the request (i.e.  `body.Threads`). 